### PR TITLE
Add functor instance to Undefinable and tests

### DIFF
--- a/src/Data/Undefinable.purs
+++ b/src/Data/Undefinable.purs
@@ -5,7 +5,7 @@ module Data.Undefinable
   , toUndefinable
   ) where
 
-import Prelude (class Eq, class Ord, class Show, (<<<), compare, eq, show)
+import Prelude (class Eq, class Ord, class Show, class Functor, (<<<), compare, eq, show, map)
 
 import Data.Function (on)
 import Data.Function.Uncurried (Fn3, runFn3)
@@ -31,6 +31,9 @@ instance eqUndefinable :: (Eq a) => Eq (Undefinable a) where
 
 instance ordUndefinable :: (Ord a) => Ord (Undefinable a) where
   compare = compare `on` toMaybe
+
+instance functorUndefinable :: Functor Undefinable where
+  map f = toUndefinable <<< map f <<< toMaybe
 
 foreign import undefined :: forall value. Undefinable value
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,30 @@
+module Test.Main where
+
+import Prelude
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, logShow)
+import Data.Maybe (Maybe(..))
+import Data.Undefinable (toUndefinable, toMaybe)
+
+main :: forall e. Eff (console :: CONSOLE | e) Unit
+main = do
+  logShow $ toUndefinable (Nothing :: Maybe Number)
+  logShow $ toUndefinable (Just 42)
+
+  logShow $ toMaybe $ toUndefinable (Nothing :: Maybe Number)
+  logShow $ toMaybe $ toUndefinable (Just 42)
+
+  logShow $ toUndefinable Nothing == toUndefinable (Just 42)
+  logShow $ toUndefinable Nothing `compare` toUndefinable (Just 42)
+
+  logShow $ (identity <$> (toUndefinable Nothing)) == toUndefinable Nothing
+  logShow $ (identity <$> (toUndefinable (Just 42))) == toUndefinable (Just 42)
+
+  logShow $ (plus1 <$> toUndefinable Nothing) == toUndefinable Nothing
+  logShow $ (plus1 <$> toUndefinable (Just 42)) == toUndefinable (Just 43)
+  logShow $ ((times2 <<< plus1) <$> toUndefinable (Just 42)) == ((map times2) <<< (map plus1) $ toUndefinable (Just 42))
+
+  where
+    identity x = x
+    plus1 x = x + 1
+    times2 x = x * 2


### PR DESCRIPTION
This PR adds a functor instance to the `Undefinable` type and adds tests as in the `purescript-nullable` library, also testing the new functor instance feature.
