### PR TITLE
version change, named function value for js backtraces

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,10 +15,10 @@
     "!LICENSE"
   ],
   "dependencies": {
-    "purescript-maybe": "^3.0.0",
-    "purescript-functions": "^3.0.0"
+    "purescript-maybe": "^4.0.0",
+    "purescript-functions": "^4.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^3.0.0"
+    "purescript-console": "^4.0.0"
   }
 }

--- a/src/Data/Undefinable.js
+++ b/src/Data/Undefinable.js
@@ -2,10 +2,10 @@
 
 exports['undefined'] = undefined;
 
-exports.undefinable = function(nothing, just, value){
+exports.undefinable = function undefinable(nothing, just, value){
   return value === undefined ? nothing : just(value);
 };
 
-exports.notUndefined = function(value){
+exports.notUndefined = function notUndefined(value){
   return value;
 };

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,12 +2,12 @@ module Test.Main where
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE, logShow)
+import Effect (Effect)
+import Effect.Console (logShow)
 import Data.Maybe (Maybe(..))
 import Data.Undefinable (toUndefinable, toMaybe)
 
-main :: Eff (console :: CONSOLE) Unit
+main :: Effect Unit
 main = do
   logShow $ toUndefinable (Nothing :: Maybe Number)
   logShow $ toUndefinable (Just 42)


### PR DESCRIPTION
Some really simple changes, to get back on the v0.12 purs train